### PR TITLE
Fix STAGING and CHICKENEGG env var to behave like they're expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,5 +115,5 @@ With this option a container will exited right after certificates update.
 * **CHMOD** Permissions for certs. Defaults to `644`.
 * **EXP_LIMIT** The number of days before expiration of the certificate before request another one. Defaults to `30`.
 * **CHECK_FREQ**: The number of days how often to perform checks. Defaults to `30`.
-* **CHICKENEGG**: Set this to 1 to generate a self signed certificate before attempting to start the process with no previous certificate. Some http servers (nginx) might not start up without a certificate file present.
+* **CHICKENEGG**: Set this to 1 to generate a self signed certificate before attempting to start the process with no previous certificate. Some http servers (nginx) might not start up without a certificate file present. Defaults to `1`.
 * **STAGING**: Set this to 1 to use the staging environment of letsencrypt to prevent rate limiting while working on your setup. Defaults to `0`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Letsencrypt cert auto getting and renewal script based on [certbot](https://hub.
 
   - [GitHub](https://github.com/vdhpieter/docker-letsencrypt-webroot)
   - [DockerHub](https://hub.docker.com/r/vdhpieter/letsencrypt-webroot/)
-  
+
 ## Contribute
 
 I took over this project from [@kvaps](https://github.com/kvaps). I'm not a docker or open source expert but will do all I can to look at issues & PR's. Help is greatly appreciated!
@@ -116,4 +116,4 @@ With this option a container will exited right after certificates update.
 * **EXP_LIMIT** The number of days before expiration of the certificate before request another one. Defaults to `30`.
 * **CHECK_FREQ**: The number of days how often to perform checks. Defaults to `30`.
 * **CHICKENEGG**: Set this to 1 to generate a self signed certificate before attempting to start the process with no previous certificate. Some http servers (nginx) might not start up without a certificate file present.
-* **STAGING**: Set this to 1 to use the staging environment of letsencrypt to prevent rate limiting while working on your setup.
+* **STAGING**: Set this to 1 to use the staging environment of letsencrypt to prevent rate limiting while working on your setup. Defaults to `0`.

--- a/start.sh
+++ b/start.sh
@@ -15,7 +15,7 @@ if [ -z "$WEBROOT_PATH" ] ; then
   exit 1
 fi
 
-if [[ -z $STAGING ]]; then
+if [[ $STAGING -eq 1 ]]; then
   echo "Using the staging environment"
   ADDITIONAL="--staging"
 fi

--- a/start.sh
+++ b/start.sh
@@ -107,7 +107,7 @@ le_check() {
 
     else
       echo "[INFO] certificate file not found for domain $DARRAYS. Starting webroot initial certificate request script..."
-      if [[ -z $CHICKENEGG ]]; then
+      if [[ $CHICKENEGG -eq 1 ]]; then
         echo "Making a temporary self signed certificate to prevent chicken and egg problems"
         openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout "/etc/letsencrypt/live/$DARRAYS/privkey.pem" -out "${cert_file}" -subj "/CN=example.com" -days 1
       fi

--- a/start.sh
+++ b/start.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-if [ -z "$DOMAINS" ] ; then
+if [[ -z $DOMAINS ]]; then
   echo "No domains set, please fill -e 'DOMAINS=example.com www.example.com'"
   exit 1
 fi
 
-if [ -z "$EMAIL" ] ; then
+if [[ -z $EMAIL ]]; then
   echo "No email set, please fill -e 'EMAIL=your@email.tld'"
   exit 1
 fi
 
-if [ -z "$WEBROOT_PATH" ] ; then
+if [[ -z $WEBROOT_PATH ]]; then
   echo "No webroot path set, please fill -e 'WEBROOT_PATH=/tmp/letsencrypt'"
   exit 1
 fi
@@ -71,7 +71,7 @@ le_renew() {
 le_check() {
     cert_file="/etc/letsencrypt/live/$DARRAYS/fullchain.pem"
 
-    if [ -f $cert_file ]; then
+    if [[ -e $cert_file ]]; then
 
         exp=$(date -d "`openssl x509 -in $cert_file -text -noout|grep "Not After"|cut -c 25-`" +%s)
         datenow=$(date -d "now" +%s)


### PR DESCRIPTION
The STAGING and CHICKENEGG env vars were doing the opposite the readme said. The new behaviour is the following:
- For STAGING: It will connect to the staging env of let's encrypt if set to 1. If set to 0 or not set it will connect to production env of let's encrypt.
- For CHICKENEGG: It will generate a dummy certificate before running the process if set to 1. This there because some http servers won't start without it. Setting it 0 or not setting it all the script expects to already have a certificate. (Will check later if this can be improved in next versions.)

Fixes #2